### PR TITLE
Move command line operations to Program.cs

### DIFF
--- a/QuantConnect.GDAXBrokerage.ToolBox/GDAXDownloaderProgram.cs
+++ b/QuantConnect.GDAXBrokerage.ToolBox/GDAXDownloaderProgram.cs
@@ -32,13 +32,6 @@ namespace QuantConnect.ToolBox.GDAXDownloader
         {
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
 
-            if (resolution.IsNullOrEmpty() || tickers.IsNullOrEmpty())
-            {
-                Console.WriteLine("GDAXDownloader ERROR: '--tickers=' or '--resolution=' parameter is missing");
-                Console.WriteLine("--tickers=ETHUSD,ETHBTC,BTCUSD,etc.");
-                Console.WriteLine("--resolution=Second/Minute/Hour/Daily");
-                Environment.Exit(1);
-            }
             var castResolution = (Resolution) Enum.Parse(typeof(Resolution), resolution);
             try
             {
@@ -50,6 +43,7 @@ namespace QuantConnect.ToolBox.GDAXDownloader
                 var downloader = new GDAXDownloader();
                 foreach (var ticker in tickers)
                 {
+                    Log.Trace("Start data download for " + ticker);
                     // Download the data
                     var symbolObject = Symbol.Create(ticker, SecurityType.Crypto, market);
                     var data = downloader.Get(new DataDownloaderGetParameters(symbolObject, castResolution, fromDate, toDate));
@@ -61,7 +55,7 @@ namespace QuantConnect.ToolBox.GDAXDownloader
                     writer.Write(distinctData);
                 }
 
-                Log.Trace("Finish data download. Press any key to continue..");
+                Log.Trace("Finish data download");
 
             }
             catch (Exception err)
@@ -70,7 +64,6 @@ namespace QuantConnect.ToolBox.GDAXDownloader
                 Log.Trace(err.Message);
                 Log.Trace(err.StackTrace);
             }
-            Console.ReadLine();
         }
 
         /// <summary>

--- a/QuantConnect.GDAXBrokerage.ToolBox/Program.cs
+++ b/QuantConnect.GDAXBrokerage.ToolBox/Program.cs
@@ -15,7 +15,9 @@
 
 using QuantConnect.Configuration;
 using QuantConnect.ToolBox.GDAXDownloader;
+using QuantConnect.Util;
 using System;
+using System.Linq;
 using static QuantConnect.Configuration.ApplicationParser;
 
 namespace QuantConnect.TemplateBrokerage.ToolBox
@@ -44,7 +46,19 @@ namespace QuantConnect.TemplateBrokerage.ToolBox
                 var toDate = optionsObject.ContainsKey("to-date")
                     ? Parse.DateTimeExact(optionsObject["to-date"].ToString(), "yyyyMMdd-HH:mm:ss")
                     : DateTime.UtcNow;
+
+                if (resolution.IsNullOrEmpty() || tickers.Any(s => s.IsNullOrEmpty()))
+                {
+                    Console.WriteLine("GDAXDownloader ERROR: '--tickers=' or '--resolution=' parameter is missing");
+                    Console.WriteLine("--tickers=ETHUSD,ETHBTC,BTCUSD,etc.");
+                    Console.WriteLine("--resolution=Second/Minute/Hour/Daily");
+                    Environment.Exit(1);
+                }
+
                 GDAXDownloaderProgram.GDAXDownloader(tickers, resolution, fromDate, toDate);
+
+                Console.WriteLine("Finish data download. Press any key to continue..");
+                Console.ReadLine();
             }
             else if (targetAppName.Contains("updater") || targetAppName.EndsWith("spu"))
             {


### PR DESCRIPTION
Not a bug fix or feature, a possible improvement. 
I would like to separate the command line interaction from the downloader itself. In this way, `GDAXDownloaderProgram.GDAXDownloader(tickers, resolution, fromDate, toDate)` can be used in any other program not depending on user input or console in general.

#### Description
I moved input ARGS (tickers and resolution) checks to `Program.cs`: with tickers check on List. 
I moved `Console.ReadLine()` to `Program.cs` so you can call `GDAXDownloaderProgram.GDAXDownloader(tickers, resolution, fromDate, toDate)` and it does not wait for the STD Input to return.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/QuantConnect/Lean.Brokerages.CoinbasePro/issues/12

#### Motivation and Context
It allows you to use `GDAXDownloaderProgram.GDAXDownloader` in any function/program with out depending on console IO

#### Requires Documentation Change

#### How Has This Been Tested?

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes. 
- [ ] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
